### PR TITLE
Output resident files to --json directory when used

### DIFF
--- a/MFTECmd/Program.cs
+++ b/MFTECmd/Program.cs
@@ -132,7 +132,7 @@ public class Program
 
             new Option<bool>(
                 "--dr",
-                "When true, dump $MFT resident files to dir specified by --csv, in 'Resident' subdirectory. Files will be named '<EntryNumber>-<SequenceNumber>_<FileName>.bin'"),
+                "When true, dump $MFT resident files to dir specified by --csv or --json, in 'Resident' subdirectory. Files will be named '<EntryNumber>-<SequenceNumber>_<FileName>.bin'"),
 
             new Option<bool>(
                 "--fls",
@@ -428,7 +428,8 @@ public class Program
                 var drDir = string.Empty;
                 if (dr)
                 {
-                    drDir = Path.Combine(csv,"Resident");
+                    var residentDirBase = !json.IsNullOrEmpty() ? json : csv;
+                    drDir = Path.Combine(residentDirBase, "Resident");
                 }
 
                 ProcessMft(f, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir);
@@ -470,7 +471,8 @@ public class Program
                     var drDir2 = string.Empty;
                     if (dr)
                     {
-                        drDir2 = $"{csv}\\Resident";
+                        var residentDirBase = !json.IsNullOrEmpty() ? json : csv;
+                        drDir2 = $"{residentDirBase}\\Resident";
                     }
 
                     ProcessMft(m, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir2);


### PR DESCRIPTION
When using `--dr` in conjunction with `--json`, resident files will be placed in a folder called `Resident` in the root directory (i.e. C:\Resident). Using `--csv` to specify an output directory as the help file implies disables `--json` and generates csv output

This change modifies the `--dr` flag so resident files are output to the folder specified by `--json` when specified, otherwise defaults back to `--csv`