### PR TITLE
nuget, add new sample commands, standardize --csv output folder in samples

### DIFF
--- a/MFTECmd/MFTECmd.csproj
+++ b/MFTECmd/MFTECmd.csproj
@@ -20,18 +20,18 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="ERZHelpers" Version="1.3.0" />
-        <PackageReference Include="Fody" Version="6.8.0">
+        <PackageReference Include="Fody" Version="6.8.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="I30" Version="1.4.2" />
         <PackageReference Include="MFT" Version="1.4.3-alpha.0.2" />
-        <PackageReference Include="Serilog" Version="3.1.1" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+        <PackageReference Include="Serilog" Version="4.0.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="CsvHelper" Version="31.0.2" />
-        <PackageReference Include="Exceptionless" Version="6.0.3" />
+        <PackageReference Include="Exceptionless" Version="6.0.4" />
         <PackageReference Include="Secure" Version="1.4.2" />
-        <PackageReference Include="ServiceStack.Text" Version="8.2.2" />
+        <PackageReference Include="ServiceStack.Text" Version="8.3.0" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />

--- a/MFTECmd/MFTECmd.csproj
+++ b/MFTECmd/MFTECmd.csproj
@@ -28,7 +28,7 @@
         <PackageReference Include="MFT" Version="1.4.3-alpha.0.2" />
         <PackageReference Include="Serilog" Version="4.0.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-        <PackageReference Include="CsvHelper" Version="31.0.2" />
+        <PackageReference Include="CsvHelper" Version="33.0.1" />
         <PackageReference Include="Exceptionless" Version="6.0.4" />
         <PackageReference Include="Secure" Version="1.4.2" />
         <PackageReference Include="ServiceStack.Text" Version="8.3.0" />

--- a/MFTECmd/Program.cs
+++ b/MFTECmd/Program.cs
@@ -55,10 +55,12 @@ public class Program
                                             @"   MFTECmd.exe -f ""C:\Temp\SomeMFT"" --json ""c:\temp\jsonout""" + "\r\n\t " +
                                             @"   MFTECmd.exe -f ""C:\Temp\SomeMFT"" --body ""c:\temp\bout"" --bdl c" + "\r\n\t " +
                                             @"   MFTECmd.exe -f ""C:\Temp\SomeMFT"" --de 5-5" + "\r\n\t " +
-                                            @"   MFTECmd.exe -f ""c:\temp\SomeJ"" --csv c:\temp" + "\r\n\t " +
+                                            @"   MFTECmd.exe -f ""C:\Temp\SomeMFT"" --csv ""c:\temp\out"" --dr --fl" + "\r\n\t " +
+                                            @"   MFTECmd.exe -f ""c:\temp\SomeJ"" --csv ""c:\temp\out""" + "\r\n\t " +
+                                            @"   MFTECmd.exe -f ""c:\temp\SomeJ"" -m ""C:\Temp\SomeMFT"" --csv ""c:\temp\out""" + "\r\n\t " +
                                             @"   MFTECmd.exe -f ""c:\temp\SomeBoot""" + "\r\n\t " +
-                                            @"   MFTECmd.exe -f ""c:\temp\SomeSecure_SDS"" --csv c:\temp" + "\r\n\t " +
-                                            @"   MFTECmd.exe -f ""c:\temp\SomeI30"" --csv c:\temp" +
+                                            @"   MFTECmd.exe -f ""c:\temp\SomeSecure_SDS"" --csv ""c:\temp\out""" + "\r\n\t " +
+                                            @"   MFTECmd.exe -f ""c:\temp\SomeI30"" --csv ""c:\temp\out""" + "\r\n\t" +
                                             "\r\n\t" +
                                             "    Short options (single letter) are prefixed with a single dash. Long commands are prefixed with two dashes";
 


### PR DESCRIPTION
This closes https://github.com/EricZimmerman/MFTECmd/pull/19 and https://github.com/EricZimmerman/MFTECmd/pull/18

tested all packages, identical output with CsvHelper v31 to v33