### PR TITLE
Add cutoff

### DIFF
--- a/MFTECmd/MFTECmd.csproj.user
+++ b/MFTECmd/MFTECmd.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_LastSelectedProfileId>C:\Users\csaig\AppData\Local\save-changesnew\bin\MFTECmd\MFTECmd\Properties\PublishProfiles\FolderProfile.pubxml</_LastSelectedProfileId>
+  </PropertyGroup>
+</Project>

--- a/MFTECmd/MFTRecordOut.cs
+++ b/MFTECmd/MFTRecordOut.cs
@@ -36,8 +36,6 @@ public class MFTRecordOut
 
     public DateTimeOffset? LastAccess0x30 { get; set; }
 
-    public DateTimeOffset? SrhType { get; set; }
-
     public long UpdateSequenceNumber { get; set; }
     public long LogfileSequenceNumber { get; set; }
 
@@ -58,7 +56,6 @@ public class MFTRecordOut
     public int OtherAttributeId { get; set; }
     public string SourceFile { get; set; }
     
-    public DateTimeOffset? SrhMode { get; set; }
 }
 
 public class FileListEntry

--- a/MFTECmd/MFTRecordOut.cs
+++ b/MFTECmd/MFTRecordOut.cs
@@ -36,6 +36,8 @@ public class MFTRecordOut
 
     public DateTimeOffset? LastAccess0x30 { get; set; }
 
+    public DateTimeOffset? SrhType { get; set; }
+
     public long UpdateSequenceNumber { get; set; }
     public long LogfileSequenceNumber { get; set; }
 
@@ -55,6 +57,8 @@ public class MFTRecordOut
     public int FnAttributeId { get; set; }
     public int OtherAttributeId { get; set; }
     public string SourceFile { get; set; }
+    
+    public DateTimeOffset? SrhMode { get; set; }
 }
 
 public class FileListEntry

--- a/MFTECmd/MFTRecordOut.cs
+++ b/MFTECmd/MFTRecordOut.cs
@@ -55,7 +55,10 @@ public class MFTRecordOut
     public int FnAttributeId { get; set; }
     public int OtherAttributeId { get; set; }
     public string SourceFile { get; set; }
-    
+
+    public string ResidentDataBase64 { get; set; }
+    public string ResidentDataHex { get; set; }
+    public string ResidentDataASCII { get; set; }
 }
 
 public class FileListEntry

--- a/MFTECmd/Program.cs
+++ b/MFTECmd/Program.cs
@@ -29,6 +29,7 @@ using Serilog.Events;
 using ServiceStack;
 using ServiceStack.Text;
 using Usn;
+using static System.Collections.Specialized.BitVector32;
 using Attribute = MFT.Attributes.Attribute;
 using CsvWriter = CsvHelper.CsvWriter;
 
@@ -188,7 +189,17 @@ public class Program
             new Option<bool>(
                 "--trace",
                 () => false,
-                "Show trace information during processing")
+                "Show trace information during processing"),
+
+            new Option<DateTime?>(
+                "--cutoff",
+                () => null,
+                "Cutoff date to filter entries (entries prior to this date will be excluded)"
+             ),
+
+            new Option<string>(
+                "--faction",
+                "cutoff search type by modified, created, deleted or all.  deleted searches by recordmodified. all is modified&created together"),
         };
 
         _rootCommand.Description = Header + "\r\n\r\n" + Footer;
@@ -232,7 +243,7 @@ public class Program
         }
     }
     
-    private static void DoWork(string f, string m, string json, string jsonf, string csv, string csvf, string body, string bodyf, string bdl, bool blf, string dd, string @do, string de, bool dr, bool fls, string ds, string dt, bool sn, bool fl, bool at, bool rs, bool vss, bool dedupe, bool debug, bool trace)
+    private static void DoWork(string f, string m, string json, string jsonf, string csv, string csvf, string body, string bodyf, string bdl, bool blf, string dd, string @do, string de, bool dr, bool fls, string ds, string dt, bool sn, bool fl, bool at, bool rs, bool vss, bool dedupe, bool debug, bool trace, DateTime? cutoff, string faction)
     {
         var levelSwitch = new LoggingLevelSwitch();
 
@@ -345,6 +356,15 @@ public class Program
             }
         }
 
+        if (!string.IsNullOrEmpty(faction) &&
+            faction != "created" &&
+            faction != "modified" &&
+            faction != "deleted" &&
+            faction != "all")
+        {
+            Log.Warning("Invalid faction '{Faction}' specified. Must be either: created or modified or deleted.", faction);
+            return;
+        }
 
         switch (ft)
         {
@@ -432,7 +452,7 @@ public class Program
                     drDir = Path.Combine(residentDirBase, "Resident");
                 }
 
-                ProcessMft(f, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir);
+                ProcessMft(f, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir, cutoff, faction);
                 break;
             case FileType.LogFile:
                 Log.Warning("$LogFile not supported yet. Exiting");
@@ -475,7 +495,7 @@ public class Program
                         drDir2 = $"{residentDirBase}\\Resident";
                     }
 
-                    ProcessMft(m, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir2);
+                    ProcessMft(m, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir2, cutoff, faction);
                 }
 
                 ProcessJ(f, vss, dedupe, csv, csvf, json, jsonf, dt);
@@ -1465,7 +1485,7 @@ public class Program
 
     
     
-    private static void ProcessMft(string file, bool vss, bool dedupe, string body, string bdl, string bodyf, bool blf, string csv, string csvf, string json, string jsonf, bool fl, string dt, string dd, string @do, bool fls, bool includeShort, bool alltimestamp, string de, bool rs, string drDir)
+    private static void ProcessMft(string file, bool vss, bool dedupe, string body, string bdl, string bodyf, bool blf, string csv, string csvf, string json, string jsonf, bool fl, string dt, string dd, string @do, bool fls, bool includeShort, bool alltimestamp, string de, bool rs, string drDir, DateTime? cutoff, string faction)
     {
         var mftFiles = new Dictionary<string, Mft>();
 
@@ -1562,6 +1582,7 @@ public class Program
 
         foreach (var mftFile in mftFiles)
         {
+            
             Log.Information(
                 "{Key}: FILE records found: {FileRecordsCount:N0} (Free records: {FreeFileRecordsCount:N0}) File size: {FileSize}",mftFile.Key,mftFile.Value.FileRecords.Count,mftFile.Value.FreeFileRecords.Count,Helper.BytesToSizeAsString(mftFile.Value.FileSize));
 
@@ -1750,8 +1771,9 @@ public class Program
 
                     try
                     {
-                        swCsv = new StreamWriter(outFile, false, Encoding.UTF8, 4096 * 4);
+                        //swCsv = new StreamWriter(outFile, false, Encoding.UTF8, 4096 * 4);
 
+                        swCsv = new StreamWriter(Console.OpenStandardOutput(), Encoding.UTF8) { AutoFlush = true };
                         _csvWriter = new CsvWriter(swCsv, CultureInfo.InvariantCulture);
 
                         var foo = _csvWriter.Context.AutoMap<MFTRecordOut>();
@@ -1845,8 +1867,8 @@ public class Program
                         }
                     }
                     
-                    ProcessRecords(mftFile.Value.FileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key);
-                    ProcessRecords(mftFile.Value.FreeFileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key);
+                    ProcessRecords(mftFile.Value.FileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, cutoff, faction);
+                    ProcessRecords(mftFile.Value.FreeFileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, cutoff, faction);
                 }
                 catch (Exception ex)
                 {
@@ -2791,9 +2813,18 @@ public class Program
         return FileType.Unknown;
     }
 
-    private static void ProcessRecords(Dictionary<string, FileRecord> records, bool includeShort, bool alltimestamp, string bdl, string drDumpDir, string mftFilePath)
+    private static void ProcessRecords(Dictionary<string, FileRecord> records, bool includeShort, bool alltimestamp, string bdl, string drDumpDir, string mftFilePath, DateTime? cutoff, string faction)
     {
-        
+
+        //if (cutoff.HasValue && mftr.LastModified0x10.HasValue &&
+        //    mftr.LastModified0x10.Value < cutoff.Value)
+        //{
+        //    isSkipped = true;
+        //    Console.WriteLine("[SKIPPED]");
+        //    continue;
+        //}
+
+
         foreach (var fr in records)
         {
             Log.Verbose(
@@ -2826,9 +2857,9 @@ public class Program
                 {
                     continue;
                 }
-
-                var mftr = GetCsvData(fr.Value, fn, null, alltimestamp, mftFilePath);
-
+               
+                var mftr = GetCsvData(fr.Value, fn, null, alltimestamp, mftFilePath, faction);
+                
                 var ads = fr.Value.GetAlternateDataStreams();
 
                 if (drDumpDir.IsNullOrEmpty() == false)
@@ -2854,55 +2885,102 @@ public class Program
 
                 mftr.HasAds = ads.Any();
 
-                _csvWriter?.WriteRecord(mftr);
+                bool isSkipped = false;
+                bool modifiedOld = false;
+                bool createdOld = false;
 
-                _mftOutRecords?.Add(mftr);
-
-                _csvWriter?.NextRecord();
-
-                if (_fileListWriter != null)
+                if (cutoff.HasValue)
                 {
-                    _fileListWriter.WriteRecord(new FileListEntry(mftr));
-                    _fileListWriter.NextRecord();
+                    if (mftr.SrhMode.HasValue)
+                    {
+                        createdOld = mftr.SrhType.HasValue && mftr.SrhType.Value < cutoff.Value;
+                        modifiedOld = mftr.SrhMode.HasValue && mftr.SrhMode.Value < cutoff.Value;
+
+                        if (createdOld && modifiedOld)
+                        {
+                            isSkipped = true;
+                            Console.WriteLine("[SKIPPED]");
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        if (mftr.SrhType.HasValue && mftr.SrhType.Value < cutoff.Value)
+                        {
+                            isSkipped = true;
+                            Console.WriteLine("[SKIPPED]");
+                            continue;
+                        }
+                    }
                 }
 
-                if (_bodyWriter != null)
+                //if (cutoff.HasValue && mftr.LastModified0x10.HasValue &&
+                //    mftr.LastModified0x10.Value < cutoff.Value)
+                //{
+                //    continue;
+                //}
+                //if (cutoff.HasValue && mftr.LastModified0x10.HasValue &&
+                //    mftr.LastModified0x10.Value < cutoff.Value)
+                //{
+                //    isSkipped = true;
+                //    Console.WriteLine("[SKIPPED]");
+                //    continue;
+                //}
+                else
                 {
-                    var f = GetBodyData(mftr, true, bdl);
 
-                    _bodyWriter.WriteRecord(f);
-                    _bodyWriter.NextRecord();
+                    _csvWriter?.WriteRecord(mftr);
 
-                    f = GetBodyData(mftr, false, bdl);
-
-                    _bodyWriter.WriteRecord(f);
-                    _bodyWriter.NextRecord();
-                }
-
-
-                foreach (var adsInfo in ads)
-                {
-                    var adsRecord = GetCsvData(fr.Value, fn, adsInfo, alltimestamp, mftFilePath);
-                    adsRecord.IsAds = true;
-                    adsRecord.OtherAttributeId = adsInfo.AttributeId;
-                    _csvWriter?.WriteRecord(adsRecord);
-
-                    _mftOutRecords?.Add(adsRecord);
+                    _mftOutRecords?.Add(mftr);
 
                     _csvWriter?.NextRecord();
 
                     if (_fileListWriter != null)
                     {
-                        _fileListWriter.WriteRecord(new FileListEntry(adsRecord));
+                        _fileListWriter.WriteRecord(new FileListEntry(mftr));
                         _fileListWriter.NextRecord();
                     }
 
                     if (_bodyWriter != null)
                     {
-                        var f1 = GetBodyData(adsRecord, true, bdl);
+                        var f = GetBodyData(mftr, true, bdl);
 
-                        _bodyWriter.WriteRecord(f1);
+                        _bodyWriter.WriteRecord(f);
                         _bodyWriter.NextRecord();
+
+                        f = GetBodyData(mftr, false, bdl);
+
+                        _bodyWriter.WriteRecord(f);
+                        _bodyWriter.NextRecord();
+                    }
+                }
+                foreach (var adsInfo in ads)
+                {
+                    var adsRecord = GetCsvData(fr.Value, fn, adsInfo, alltimestamp, mftFilePath, faction);
+                    adsRecord.IsAds = true;
+                    adsRecord.OtherAttributeId = adsInfo.AttributeId;
+
+                    if (!isSkipped)
+                    {
+                        _csvWriter?.WriteRecord(adsRecord);
+
+                        _mftOutRecords?.Add(adsRecord);
+
+                        _csvWriter?.NextRecord();
+
+                        if (_fileListWriter != null)
+                        {
+                            _fileListWriter.WriteRecord(new FileListEntry(adsRecord));
+                            _fileListWriter.NextRecord();
+                        }
+
+                        if (_bodyWriter != null)
+                        {
+                            var f1 = GetBodyData(adsRecord, true, bdl);
+
+                            _bodyWriter.WriteRecord(f1);
+                            _bodyWriter.NextRecord();
+                        }
                     }
                 }
             }
@@ -3016,7 +3094,7 @@ public class Program
         return b;
     }
 
-    public static MFTRecordOut GetCsvData(FileRecord fr, FileName fn, AdsInfo adsinfo, bool alltimestamp, string mftFilePath)
+    public static MFTRecordOut GetCsvData(FileRecord fr, FileName fn, AdsInfo adsinfo, bool alltimestamp, string mftFilePath, string faction)
     {
         var mftr = new MFTRecordOut
         {
@@ -3030,7 +3108,15 @@ public class Program
             ParentSequenceNumber = fn.FileInfo.ParentMftRecord.MftSequenceNumber,
             NameType = fn.FileInfo.NameType,
             FnAttributeId = fn.AttributeNumber,
-            SourceFile = mftFilePath
+            SourceFile = mftFilePath,
+            SrhType = faction == "created"  ? fn.FileInfo.CreatedOn :
+                      faction == "modified" ? fn.FileInfo.ContentModifiedOn :
+                      faction == "deleted"  ? fn.FileInfo.RecordModifiedOn :
+                      faction == "all"      ? fn.FileInfo.CreatedOn :
+                      (DateTime?)null,
+
+
+            SrhMode = faction == "all" ? fn.FileInfo.ContentModifiedOn : (DateTime?)null
         };
 
         if (mftr.IsDirectory == false)

--- a/MFTECmd/Program.cs
+++ b/MFTECmd/Program.cs
@@ -29,8 +29,6 @@ using Serilog.Events;
 using ServiceStack;
 using ServiceStack.Text;
 using Usn;
-using static System.Collections.Specialized.BitVector32;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 using Attribute = MFT.Attributes.Attribute;
 using CsvWriter = CsvHelper.CsvWriter;
 
@@ -192,12 +190,25 @@ public class Program
                 () => false,
                 "Show trace information during processing"),
 
+            new Option<bool>(
+                "--ir",
+                () => false,
+                "Include resident data in JSON/CSV output"),
+
+            new Option<string>(
+                "--re",
+                "Comma-separated list of extensions to include for resident data (e.g., '.txt,.ps1,.bat'). If omitted, includes all"),
+
+            new Option<int>(
+                "--rm",
+                () => 1024,
+                "Maximum size in bytes for resident data to include (default: 1024, max: 1024000)"),
+
             new Option<DateTimeOffset?>(
                 "--cutoff",
                 () => null,
                 "Cutoff date to filter entries (entries prior to this date will be excluded)"
              ),
-
         };
 
         _rootCommand.Description = Header + "\r\n\r\n" + Footer;
@@ -241,7 +252,7 @@ public class Program
         }
     }
     
-    private static void DoWork(string f, string m, string json, string jsonf, string csv, string csvf, string body, string bodyf, string bdl, bool blf, string dd, string @do, string de, bool dr, bool fls, string ds, string dt, bool sn, bool fl, bool at, bool rs, bool vss, bool dedupe, bool debug, bool trace, DateTimeOffset? cutoff)
+    private static void DoWork(string f, string m, string json, string jsonf, string csv, string csvf, string body, string bodyf, string bdl, bool blf, string dd, string @do, string de, bool dr, bool fls, string ds, string dt, bool sn, bool fl, bool at, bool rs, bool vss, bool dedupe, bool debug, bool trace, bool ir, string re, int rm, DateTimeOffset? cutoff)
     {
         var levelSwitch = new LoggingLevelSwitch();
 
@@ -445,7 +456,7 @@ public class Program
                     drDir = Path.Combine(residentDirBase, "Resident");
                 }
 
-                ProcessMft(f, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir, cutoff);
+                ProcessMft(f, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de, rs, drDir, ir, re, rm, cutoff);
                 break;
             case FileType.LogFile:
                 Log.Warning("$LogFile not supported yet. Exiting");
@@ -488,7 +499,7 @@ public class Program
                         drDir2 = $"{residentDirBase}\\Resident";
                     }
 
-                    ProcessMft(m, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir2, cutoff);
+                    ProcessMft(m, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de, rs, drDir2, ir, re, rm, cutoff);
                 }
 
                 ProcessJ(f, vss, dedupe, csv, csvf, json, jsonf, dt);
@@ -1478,7 +1489,7 @@ public class Program
 
     
     
-    private static void ProcessMft(string file, bool vss, bool dedupe, string body, string bdl, string bodyf, bool blf, string csv, string csvf, string json, string jsonf, bool fl, string dt, string dd, string @do, bool fls, bool includeShort, bool alltimestamp, string de, bool rs, string drDir, DateTimeOffset? cutoff)
+    private static void ProcessMft(string file, bool vss, bool dedupe, string body, string bdl, string bodyf, bool blf, string csv, string csvf, string json, string jsonf, bool fl, string dt, string dd, string @do, bool fls, bool includeShort, bool alltimestamp, string de, bool rs, string drDir, bool includeResident, string residentExt, int residentMaxSize, DateTimeOffset? cutoff)
     {
         var mftFiles = new Dictionary<string, Mft>();
 
@@ -1575,7 +1586,6 @@ public class Program
 
         foreach (var mftFile in mftFiles)
         {
-            
             Log.Information(
                 "{Key}: FILE records found: {FileRecordsCount:N0} (Free records: {FreeFileRecordsCount:N0}) File size: {FileSize}",mftFile.Key,mftFile.Value.FileRecords.Count,mftFile.Value.FreeFileRecords.Count,Helper.BytesToSizeAsString(mftFile.Value.FileSize));
 
@@ -1772,6 +1782,7 @@ public class Program
                         {
                             swCsv = new StreamWriter(Console.OpenStandardOutput(), Encoding.UTF8) { AutoFlush = true };
                         }
+
                         _csvWriter = new CsvWriter(swCsv, CultureInfo.InvariantCulture);
 
                         var foo = _csvWriter.Context.AutoMap<MFTRecordOut>();
@@ -1865,8 +1876,8 @@ public class Program
                         }
                     }
                     
-                    ProcessRecords(mftFile.Value.FileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, cutoff);
-                    ProcessRecords(mftFile.Value.FreeFileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, cutoff);
+                    ProcessRecords(mftFile.Value.FileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, includeResident, residentExt, residentMaxSize, cutoff);
+                    ProcessRecords(mftFile.Value.FreeFileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, includeResident, residentExt, residentMaxSize, cutoff);
                 }
                 catch (Exception ex)
                 {
@@ -2717,7 +2728,7 @@ public class Program
                 {
                     var rawFiles = Helper.GetRawFiles(ll);
 
-                    rawFiles.First().FileStream.Read(buff, 0, 50);
+                    rawFiles.First().FileStream.ReadExactly(buff, 0, 50);
                 }
                 catch (Exception e)
                 {
@@ -2811,9 +2822,9 @@ public class Program
         return FileType.Unknown;
     }
 
-    private static void ProcessRecords(Dictionary<string, FileRecord> records, bool includeShort, bool alltimestamp, string bdl, string drDumpDir, string mftFilePath, DateTimeOffset? cutoff)
+    private static void ProcessRecords(Dictionary<string, FileRecord> records, bool includeShort, bool alltimestamp, string bdl, string drDumpDir, string mftFilePath, bool includeResident, string residentExt, int residentMaxSize, DateTimeOffset? cutoff)
     {
-
+        
         foreach (var fr in records)
         {
             Log.Verbose(
@@ -2846,9 +2857,9 @@ public class Program
                 {
                     continue;
                 }
-               
-                var mftr = GetCsvData(fr.Value, fn, null, alltimestamp, mftFilePath);
-                
+
+                var mftr = GetCsvData(fr.Value, fn, null, alltimestamp, mftFilePath, includeResident, residentExt, residentMaxSize);
+
                 var ads = fr.Value.GetAlternateDataStreams();
 
                 if (drDumpDir.IsNullOrEmpty() == false)
@@ -2873,8 +2884,7 @@ public class Program
                 
 
                 mftr.HasAds = ads.Any();
-
-                if (cutoff.HasValue) 
+                if (cutoff.HasValue)
                 {
                     //if (mftr.LastModified0x10.HasValue)
                     //{
@@ -2891,9 +2901,10 @@ public class Program
                     )
                     {
                         _csvWriter?.WriteRecord(mftr);
-                        _mftOutRecords?.Add(mftr);
-                        _csvWriter?.NextRecord();
 
+                        _mftOutRecords?.Add(mftr);
+
+                        _csvWriter?.NextRecord();
 
                         if (_fileListWriter != null)
                         {
@@ -2914,17 +2925,17 @@ public class Program
                             _bodyWriter.NextRecord();
                         }
 
+
                         foreach (var adsInfo in ads)
                         {
-                            var adsRecord = GetCsvData(fr.Value, fn, adsInfo, alltimestamp, mftFilePath);
+                            var adsRecord = GetCsvData(fr.Value, fn, adsInfo, alltimestamp, mftFilePath, includeResident, residentExt, residentMaxSize);
                             adsRecord.IsAds = true;
                             adsRecord.OtherAttributeId = adsInfo.AttributeId;
-
-
                             _csvWriter?.WriteRecord(adsRecord);
-                            _mftOutRecords?.Add(adsRecord);
-                            _csvWriter?.NextRecord();
 
+                            _mftOutRecords?.Add(adsRecord);
+
+                            _csvWriter?.NextRecord();
 
                             if (_fileListWriter != null)
                             {
@@ -2945,9 +2956,10 @@ public class Program
                 else
                 {
                     _csvWriter?.WriteRecord(mftr);
-                    _mftOutRecords?.Add(mftr);
-                    _csvWriter?.NextRecord();
 
+                    _mftOutRecords?.Add(mftr);
+
+                    _csvWriter?.NextRecord();
 
                     if (_fileListWriter != null)
                     {
@@ -2968,17 +2980,17 @@ public class Program
                         _bodyWriter.NextRecord();
                     }
 
+
                     foreach (var adsInfo in ads)
                     {
-                        var adsRecord = GetCsvData(fr.Value, fn, adsInfo, alltimestamp, mftFilePath);
+                        var adsRecord = GetCsvData(fr.Value, fn, adsInfo, alltimestamp, mftFilePath, includeResident, residentExt, residentMaxSize);
                         adsRecord.IsAds = true;
                         adsRecord.OtherAttributeId = adsInfo.AttributeId;
-
-
                         _csvWriter?.WriteRecord(adsRecord);
-                        _mftOutRecords?.Add(adsRecord);
-                        _csvWriter?.NextRecord();
 
+                        _mftOutRecords?.Add(adsRecord);
+
+                        _csvWriter?.NextRecord();
 
                         if (_fileListWriter != null)
                         {
@@ -3106,7 +3118,60 @@ public class Program
         return b;
     }
 
-    public static MFTRecordOut GetCsvData(FileRecord fr, FileName fn, AdsInfo adsinfo, bool alltimestamp, string mftFilePath)
+    private static void PopulateResidentData(MFTRecordOut mftr, FileRecord fr, string residentExt, int residentMaxSize)
+    {
+        if (mftr.FileSize > (ulong)residentMaxSize)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(residentExt))
+        {
+            var allowedExtensions = new HashSet<string>(
+                residentExt.Split(',').Select(e => e.Trim().ToLowerInvariant()),
+                StringComparer.OrdinalIgnoreCase
+            );
+
+            if (!string.IsNullOrEmpty(mftr.Extension) && 
+                !allowedExtensions.Contains(mftr.Extension.ToLowerInvariant()))
+            {
+                return;
+            }
+        }
+
+        var dataAttrs = fr.Attributes.Where(t => 
+            t.AttributeType == AttributeType.Data && t.IsResident).ToList();
+
+        foreach (var attr in dataAttrs)
+        {
+            var dataAttr = attr as Data;
+            if (dataAttr?.ResidentData?.Data != null)
+            {
+                var data = dataAttr.ResidentData.Data;
+
+                mftr.ResidentDataBase64 = Convert.ToBase64String(data);
+
+                mftr.ResidentDataHex = BitConverter.ToString(data);
+
+                try
+                {
+                    var text = Encoding.UTF8.GetString(data);
+                    if (text.All(c => char.IsControl(c) || char.IsWhiteSpace(c) || 
+                        (c >= 32 && c <= 126) || c == '\r' || c == '\n' || c == '\t'))
+                    {
+                        mftr.ResidentDataASCII = text;
+                    }
+                }
+                catch
+                {
+                }
+
+                break;
+            }
+        }
+    }
+
+    public static MFTRecordOut GetCsvData(FileRecord fr, FileName fn, AdsInfo adsinfo, bool alltimestamp, string mftFilePath, bool includeResident, string residentExt, int residentMaxSize)
     {
         var mftr = new MFTRecordOut
         {
@@ -3120,7 +3185,7 @@ public class Program
             ParentSequenceNumber = fn.FileInfo.ParentMftRecord.MftSequenceNumber,
             NameType = fn.FileInfo.NameType,
             FnAttributeId = fn.AttributeNumber,
-            SourceFile = mftFilePath,
+            SourceFile = mftFilePath
         };
 
         if (mftr.IsDirectory == false)
@@ -3247,6 +3312,11 @@ public class Program
             mftr.LastModified0x10 = fn.FileInfo.ContentModifiedOn;
             mftr.LastRecordChange0x10 = fn.FileInfo.RecordModifiedOn;
             mftr.LastAccess0x10 = fn.FileInfo.LastAccessedOn;
+        }
+
+        if (includeResident && adsinfo == null)
+        {
+            PopulateResidentData(mftr, fr, residentExt, residentMaxSize);
         }
 
         return mftr;

--- a/MFTECmd/Program.cs
+++ b/MFTECmd/Program.cs
@@ -30,6 +30,7 @@ using ServiceStack;
 using ServiceStack.Text;
 using Usn;
 using static System.Collections.Specialized.BitVector32;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 using Attribute = MFT.Attributes.Attribute;
 using CsvWriter = CsvHelper.CsvWriter;
 
@@ -191,15 +192,12 @@ public class Program
                 () => false,
                 "Show trace information during processing"),
 
-            new Option<DateTime?>(
+            new Option<DateTimeOffset?>(
                 "--cutoff",
                 () => null,
                 "Cutoff date to filter entries (entries prior to this date will be excluded)"
              ),
 
-            new Option<string>(
-                "--faction",
-                "cutoff search type by modified, created, deleted or all.  deleted searches by recordmodified. all is modified&created together"),
         };
 
         _rootCommand.Description = Header + "\r\n\r\n" + Footer;
@@ -243,7 +241,7 @@ public class Program
         }
     }
     
-    private static void DoWork(string f, string m, string json, string jsonf, string csv, string csvf, string body, string bodyf, string bdl, bool blf, string dd, string @do, string de, bool dr, bool fls, string ds, string dt, bool sn, bool fl, bool at, bool rs, bool vss, bool dedupe, bool debug, bool trace, DateTime? cutoff, string faction)
+    private static void DoWork(string f, string m, string json, string jsonf, string csv, string csvf, string body, string bodyf, string bdl, bool blf, string dd, string @do, string de, bool dr, bool fls, string ds, string dt, bool sn, bool fl, bool at, bool rs, bool vss, bool dedupe, bool debug, bool trace, DateTimeOffset? cutoff)
     {
         var levelSwitch = new LoggingLevelSwitch();
 
@@ -356,14 +354,9 @@ public class Program
             }
         }
 
-        if (!string.IsNullOrEmpty(faction) &&
-            faction != "created" &&
-            faction != "modified" &&
-            faction != "deleted" &&
-            faction != "all")
+        if (cutoff.HasValue)
         {
-            Log.Warning("Invalid faction '{Faction}' specified. Must be either: created or modified or deleted.", faction);
-            return;
+            cutoff = cutoff.Value.ToUniversalTime();
         }
 
         switch (ft)
@@ -452,7 +445,7 @@ public class Program
                     drDir = Path.Combine(residentDirBase, "Resident");
                 }
 
-                ProcessMft(f, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir, cutoff, faction);
+                ProcessMft(f, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir, cutoff);
                 break;
             case FileType.LogFile:
                 Log.Warning("$LogFile not supported yet. Exiting");
@@ -495,7 +488,7 @@ public class Program
                         drDir2 = $"{residentDirBase}\\Resident";
                     }
 
-                    ProcessMft(m, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir2, cutoff, faction);
+                    ProcessMft(m, vss, dedupe, body, bdl, bodyf, blf, csv, csvf, json, jsonf, fl, dt, dd, @do, fls, sn, at, de,rs,drDir2, cutoff);
                 }
 
                 ProcessJ(f, vss, dedupe, csv, csvf, json, jsonf, dt);
@@ -1485,7 +1478,7 @@ public class Program
 
     
     
-    private static void ProcessMft(string file, bool vss, bool dedupe, string body, string bdl, string bodyf, bool blf, string csv, string csvf, string json, string jsonf, bool fl, string dt, string dd, string @do, bool fls, bool includeShort, bool alltimestamp, string de, bool rs, string drDir, DateTime? cutoff, string faction)
+    private static void ProcessMft(string file, bool vss, bool dedupe, string body, string bdl, string bodyf, bool blf, string csv, string csvf, string json, string jsonf, bool fl, string dt, string dd, string @do, bool fls, bool includeShort, bool alltimestamp, string de, bool rs, string drDir, DateTimeOffset? cutoff)
     {
         var mftFiles = new Dictionary<string, Mft>();
 
@@ -1771,9 +1764,14 @@ public class Program
 
                     try
                     {
-                        //swCsv = new StreamWriter(outFile, false, Encoding.UTF8, 4096 * 4);
-
-                        swCsv = new StreamWriter(Console.OpenStandardOutput(), Encoding.UTF8) { AutoFlush = true };
+                        if (!cutoff.HasValue)
+                        {
+                            swCsv = new StreamWriter(outFile, false, Encoding.UTF8, 4096 * 4);
+                        }
+                        else
+                        {
+                            swCsv = new StreamWriter(Console.OpenStandardOutput(), Encoding.UTF8) { AutoFlush = true };
+                        }
                         _csvWriter = new CsvWriter(swCsv, CultureInfo.InvariantCulture);
 
                         var foo = _csvWriter.Context.AutoMap<MFTRecordOut>();
@@ -1867,8 +1865,8 @@ public class Program
                         }
                     }
                     
-                    ProcessRecords(mftFile.Value.FileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, cutoff, faction);
-                    ProcessRecords(mftFile.Value.FreeFileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, cutoff, faction);
+                    ProcessRecords(mftFile.Value.FileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, cutoff);
+                    ProcessRecords(mftFile.Value.FreeFileRecords, includeShort, alltimestamp, bdl,drDir,mftFile.Key, cutoff);
                 }
                 catch (Exception ex)
                 {
@@ -2813,17 +2811,8 @@ public class Program
         return FileType.Unknown;
     }
 
-    private static void ProcessRecords(Dictionary<string, FileRecord> records, bool includeShort, bool alltimestamp, string bdl, string drDumpDir, string mftFilePath, DateTime? cutoff, string faction)
+    private static void ProcessRecords(Dictionary<string, FileRecord> records, bool includeShort, bool alltimestamp, string bdl, string drDumpDir, string mftFilePath, DateTimeOffset? cutoff)
     {
-
-        //if (cutoff.HasValue && mftr.LastModified0x10.HasValue &&
-        //    mftr.LastModified0x10.Value < cutoff.Value)
-        //{
-        //    isSkipped = true;
-        //    Console.WriteLine("[SKIPPED]");
-        //    continue;
-        //}
-
 
         foreach (var fr in records)
         {
@@ -2858,7 +2847,7 @@ public class Program
                     continue;
                 }
                
-                var mftr = GetCsvData(fr.Value, fn, null, alltimestamp, mftFilePath, faction);
+                var mftr = GetCsvData(fr.Value, fn, null, alltimestamp, mftFilePath);
                 
                 var ads = fr.Value.GetAlternateDataStreams();
 
@@ -2885,55 +2874,80 @@ public class Program
 
                 mftr.HasAds = ads.Any();
 
-                bool isSkipped = false;
-                bool modifiedOld = false;
-                bool createdOld = false;
-
-                if (cutoff.HasValue)
+                if (cutoff.HasValue) 
                 {
-                    if (mftr.SrhMode.HasValue)
+                    //if (mftr.LastModified0x10.HasValue)
+                    //{
+                    //    Console.Error.WriteLine(
+                    //        $"Entry={mftr.EntryNumber}-{mftr.SequenceNumber} " +
+                    //        $"LastModified0x10={mftr.LastModified0x10.Value:O} " +
+                    //        $"LastModified0x10Utc={mftr.LastModified0x10.Value.ToUniversalTime():O} " +
+                    //        $"Cutoff={cutoff.Value:O} " +
+                    //        $"CutoffUtc={cutoff.Value.ToUniversalTime():O}");
+                    //}
+                    if (
+                        (mftr.Created0x10.HasValue && mftr.Created0x10.Value >= cutoff.Value) ||
+                        (mftr.LastModified0x10.HasValue && mftr.LastModified0x10.Value >= cutoff.Value)
+                    )
                     {
-                        createdOld = mftr.SrhType.HasValue && mftr.SrhType.Value < cutoff.Value;
-                        modifiedOld = mftr.SrhMode.HasValue && mftr.SrhMode.Value < cutoff.Value;
+                        _csvWriter?.WriteRecord(mftr);
+                        _mftOutRecords?.Add(mftr);
+                        _csvWriter?.NextRecord();
 
-                        if (createdOld && modifiedOld)
+
+                        if (_fileListWriter != null)
                         {
-                            isSkipped = true;
-                            Console.WriteLine("[SKIPPED]");
-                            continue;
+                            _fileListWriter.WriteRecord(new FileListEntry(mftr));
+                            _fileListWriter.NextRecord();
                         }
-                    }
-                    else
-                    {
-                        if (mftr.SrhType.HasValue && mftr.SrhType.Value < cutoff.Value)
+
+                        if (_bodyWriter != null)
                         {
-                            isSkipped = true;
-                            Console.WriteLine("[SKIPPED]");
-                            continue;
+                            var f = GetBodyData(mftr, true, bdl);
+
+                            _bodyWriter.WriteRecord(f);
+                            _bodyWriter.NextRecord();
+
+                            f = GetBodyData(mftr, false, bdl);
+
+                            _bodyWriter.WriteRecord(f);
+                            _bodyWriter.NextRecord();
+                        }
+
+                        foreach (var adsInfo in ads)
+                        {
+                            var adsRecord = GetCsvData(fr.Value, fn, adsInfo, alltimestamp, mftFilePath);
+                            adsRecord.IsAds = true;
+                            adsRecord.OtherAttributeId = adsInfo.AttributeId;
+
+
+                            _csvWriter?.WriteRecord(adsRecord);
+                            _mftOutRecords?.Add(adsRecord);
+                            _csvWriter?.NextRecord();
+
+
+                            if (_fileListWriter != null)
+                            {
+                                _fileListWriter.WriteRecord(new FileListEntry(adsRecord));
+                                _fileListWriter.NextRecord();
+                            }
+
+                            if (_bodyWriter != null)
+                            {
+                                var f1 = GetBodyData(adsRecord, true, bdl);
+
+                                _bodyWriter.WriteRecord(f1);
+                                _bodyWriter.NextRecord();
+                            }
                         }
                     }
                 }
-
-                //if (cutoff.HasValue && mftr.LastModified0x10.HasValue &&
-                //    mftr.LastModified0x10.Value < cutoff.Value)
-                //{
-                //    continue;
-                //}
-                //if (cutoff.HasValue && mftr.LastModified0x10.HasValue &&
-                //    mftr.LastModified0x10.Value < cutoff.Value)
-                //{
-                //    isSkipped = true;
-                //    Console.WriteLine("[SKIPPED]");
-                //    continue;
-                //}
                 else
                 {
-
                     _csvWriter?.WriteRecord(mftr);
-
                     _mftOutRecords?.Add(mftr);
-
                     _csvWriter?.NextRecord();
+
 
                     if (_fileListWriter != null)
                     {
@@ -2953,20 +2967,18 @@ public class Program
                         _bodyWriter.WriteRecord(f);
                         _bodyWriter.NextRecord();
                     }
-                }
-                foreach (var adsInfo in ads)
-                {
-                    var adsRecord = GetCsvData(fr.Value, fn, adsInfo, alltimestamp, mftFilePath, faction);
-                    adsRecord.IsAds = true;
-                    adsRecord.OtherAttributeId = adsInfo.AttributeId;
 
-                    if (!isSkipped)
+                    foreach (var adsInfo in ads)
                     {
+                        var adsRecord = GetCsvData(fr.Value, fn, adsInfo, alltimestamp, mftFilePath);
+                        adsRecord.IsAds = true;
+                        adsRecord.OtherAttributeId = adsInfo.AttributeId;
+
+
                         _csvWriter?.WriteRecord(adsRecord);
-
                         _mftOutRecords?.Add(adsRecord);
-
                         _csvWriter?.NextRecord();
+
 
                         if (_fileListWriter != null)
                         {
@@ -3094,7 +3106,7 @@ public class Program
         return b;
     }
 
-    public static MFTRecordOut GetCsvData(FileRecord fr, FileName fn, AdsInfo adsinfo, bool alltimestamp, string mftFilePath, string faction)
+    public static MFTRecordOut GetCsvData(FileRecord fr, FileName fn, AdsInfo adsinfo, bool alltimestamp, string mftFilePath)
     {
         var mftr = new MFTRecordOut
         {
@@ -3109,14 +3121,6 @@ public class Program
             NameType = fn.FileInfo.NameType,
             FnAttributeId = fn.AttributeNumber,
             SourceFile = mftFilePath,
-            SrhType = faction == "created"  ? fn.FileInfo.CreatedOn :
-                      faction == "modified" ? fn.FileInfo.ContentModifiedOn :
-                      faction == "deleted"  ? fn.FileInfo.RecordModifiedOn :
-                      faction == "all"      ? fn.FileInfo.CreatedOn :
-                      (DateTime?)null,
-
-
-            SrhMode = faction == "all" ? fn.FileInfo.ContentModifiedOn : (DateTime?)null
         };
 
         if (mftr.IsDirectory == false)


### PR DESCRIPTION
First change modified to print to stdout.

--cutoff 2025-10-19T13:45:30Z

added flag        all records time less than that date are printed as [SKIPPED]. so software to count the record number and give progress.

--faction        modified, created, deleted or all. 

deleted is by recordmodified time
all is both times modified or created less than cutoff


I use your app in my file search software and use stdout directly to memory. The cutoff increases efficiency due to less size in the panda dataframe. cutoff is a good way to search for files output to a file as the filesize is less.
